### PR TITLE
Fix issue #3 in tooltip_template._on_mouse_entered()

### DIFF
--- a/addons/tooltips_pro/scripts/tooltip_template.gd
+++ b/addons/tooltips_pro/scripts/tooltip_template.gd
@@ -220,7 +220,8 @@ func _on_mouse_entered() -> void:
 		TooltipEnums.TooltipState.LOCKED:
 			TooltipManager.collapse_tooltip_stack(TooltipManager.mouse_tooltip_stack.find(self))
 		TooltipEnums.TooltipState.UNLOCKING:
-			trigger.cancel_unlock_delay()
+			if trigger:
+				trigger.cancel_unlock_delay()
 
 
 func _on_mouse_exited() -> void:


### PR DESCRIPTION
Proposing this PR to fix issue #3 

The fix is simply adding a single if-check of defensive programming where it's made certain that the trigger exists before accessing it.

I suppose a wider fix to secure more known and potential issues would be to find the cases where trigger references are lost and then still attempted to be manipulated.