### PR TITLE
Added safety checks and disconnect TooltipTrigger signals on Remove

### DIFF
--- a/addons/tooltips_pro/scripts/tooltip_manager.gd
+++ b/addons/tooltips_pro/scripts/tooltip_manager.gd
@@ -484,6 +484,9 @@ func remove_tooltip(tooltip: Tooltip, modulate: bool = true) -> void:
 			for i in mouse_tooltip_stack.size():
 				mouse_tooltip_stack[i].set_stack_position_modulate(i)
 	
+	for child_trigger in tooltip.child_trigger_nodes:
+		child_trigger.disconnect_signals()
+	
 	await tooltip.tween_out()
 	
 	tooltip.queue_free()

--- a/addons/tooltips_pro/scripts/tooltip_manager.gd
+++ b/addons/tooltips_pro/scripts/tooltip_manager.gd
@@ -435,9 +435,9 @@ func collapse_tooltip_stack(index: int = -1, collapse_focus_stack: bool = false)
 			stack[0].state = TooltipEnums.TooltipState.UNLOCKING
 			
 			var wait_time = tooltip_settings.unlock_delay
-			if stack[0].trigger.tooltip_settings_override:
+			if stack[0].trigger && stack[0].trigger.tooltip_settings_override:
 				wait_time = stack[0].trigger.tooltip_settings_override.unlock_delay
-				
+			
 			await get_tree().create_timer(wait_time).timeout
 		
 		if stack[0] == null:
@@ -460,8 +460,16 @@ func force_close_stack():
 		remove_tooltip(tooltip, false)
 
 func remove_tooltip(tooltip: Tooltip, modulate: bool = true) -> void:
-	tooltip.trigger.on_tooltip_removed()
-	if tooltip.trigger.trigger_mode == TooltipEnums.TriggerMode.FOCUS_ONLY:
+	if tooltip.state == TooltipEnums.TooltipState.REMOVE:
+		return
+	else:
+		tooltip.state = TooltipEnums.TooltipState.REMOVE
+	
+	follow_mouse = false
+	if tooltip.trigger:
+		tooltip.trigger.on_tooltip_removed()
+	
+	if tooltip.trigger && tooltip.trigger.trigger_mode == TooltipEnums.TriggerMode.FOCUS_ONLY:
 		focus_tooltip_stack.erase(tooltip)
 		if focus_tooltip_stack.size() == 0:
 			is_collapsing_stack = false
@@ -479,5 +487,3 @@ func remove_tooltip(tooltip: Tooltip, modulate: bool = true) -> void:
 	await tooltip.tween_out()
 	
 	tooltip.queue_free()
-	
-	follow_mouse = false

--- a/addons/tooltips_pro/scripts/tooltip_template.gd
+++ b/addons/tooltips_pro/scripts/tooltip_template.gd
@@ -205,7 +205,7 @@ func tween_in():
 func tween_out():
 	if not use_tween_out:
 		return
-		
+	
 	if tween:
 		tween.kill()
 	tween = create_tween()
@@ -227,6 +227,9 @@ func _on_mouse_entered() -> void:
 
 
 func _on_mouse_exited() -> void:
+	if state == TooltipEnums.TooltipState.REMOVE:
+		return
+		
 	stack_coroutine_manager.force_close_stack_run(self)
 	
 	

--- a/addons/tooltips_pro/scripts/tooltip_template.gd
+++ b/addons/tooltips_pro/scripts/tooltip_template.gd
@@ -215,6 +215,9 @@ func tween_out():
 
 
 func _on_mouse_entered() -> void:
+	if state == TooltipEnums.TooltipState.REMOVE:
+		return
+	
 	stack_coroutine_manager.free_coroutines()
 	match state:
 		TooltipEnums.TooltipState.LOCKED:

--- a/addons/tooltips_pro/scripts/tooltip_trigger.gd
+++ b/addons/tooltips_pro/scripts/tooltip_trigger.gd
@@ -187,6 +187,26 @@ func init_signals() -> void:
 		return
 
 
+func disconnect_signals() -> void:
+	if control_node:
+		if control_node.mouse_entered.is_connected(_on_mouse_entered):
+			control_node.mouse_entered.disconnect(_on_mouse_entered)
+		if control_node.mouse_exited.is_connected(_on_mouse_exited):
+			control_node.mouse_exited.disconnect(_on_mouse_exited)
+	if collision_object_2d_node:
+		if collision_object_2d_node.mouse_entered.is_connected(_on_mouse_entered):
+			collision_object_2d_node.mouse_entered.disconnect(_on_mouse_entered)
+		if collision_object_2d_node.mouse_entered.is_connected(_on_mouse_entered_2d):
+			collision_object_2d_node.mouse_entered.disconnect(_on_mouse_entered_2d)
+		if collision_object_2d_node.mouse_exited.is_connected(_on_mouse_exited):
+			collision_object_2d_node.mouse_exited.disconnect(_on_mouse_exited)
+	if collision_object_3d_node:
+		if collision_object_3d_node.mouse_entered.is_connected(_on_mouse_entered):
+			collision_object_3d_node.mouse_entered.disconnect(_on_mouse_entered)
+		if collision_object_3d_node.mouse_exited.is_connected(_on_mouse_exited):
+			collision_object_3d_node.mouse_exited.disconnect(_on_mouse_exited)
+
+
 func try_await_open_delay(screen_pos := Vector2.ZERO, active_state := TooltipEnums.TriggerState.ACTIVE_MOUSE_ENTERED):
 	var delay = TooltipManager.tooltip_settings.open_delay
 	if tooltip_settings_override:


### PR DESCRIPTION
This should close issues #3 and #5 and prevent other funny business while rapidly moving the mouse in and out of TooltipTriggers with little to no closing/unlocking delay or while in AutoLock mode.